### PR TITLE
Support RSA_PKCS mechanism

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -95,6 +95,7 @@ export function getProviderInfo(slot: Slot) {
             case "SHA512":
                 algName = "SHA-512";
                 break;
+            case "RSA_PKCS":
             case "SHA1_RSA_PKCS":
             case "SHA256_RSA_PKCS":
             case "SHA384_RSA_PKCS":


### PR DESCRIPTION
## RSA_PKCS

If PKCS#11 module supports only `RSA_PKCS` mechanism, then `node-webcrypto-p11` calculates hash of incoming message using `NodeJS` crypto, encapsulates hash for next signing/verifying.

If PKCS#11 module supports `RSA_PKCS` and `SHA_RSA_PKCS`, application uses  SHA_RSA_PKCS mechanism

- added RSA_PKCS test
- fixed #27 