### PR TITLE
Support always authenticate for private keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "url": "https://github.com/PeculiarVentures/node-webcrypto-p11.git"
   },
   "dependencies": {
-    "@peculiar/asn1-schema": "^2.1.9",
-    "@peculiar/asn1-x509": "^2.1.9",
+    "@peculiar/asn1-schema": "^2.2.0",
+    "@peculiar/asn1-x509": "^2.2.0",
     "@peculiar/json-schema": "^1.1.12",
-    "@peculiar/x509": "^1.7.0",
-    "graphene-pk11": "^2.3.0",
+    "@peculiar/x509": "^1.8.1",
+    "graphene-pk11": "^2.3.2",
     "pkcs11js": "^1.3.0",
     "pvtsutils": "^1.3.2",
     "tslib": "^2.4.0",
@@ -59,15 +59,15 @@
   "devDependencies": {
     "@peculiar/webcrypto-test": "^1.0.7",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.44",
+    "@types/node": "^18.6.1",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
-    "rollup": "^2.75.6",
+    "rollup": "^2.77.0",
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-typescript2": "^0.32.1",
-    "ts-node": "^10.8.1",
+    "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
-    "typescript": "^4.7.3"
+    "typescript": "^4.7.4"
   },
   "funding": {
     "type": "github",

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -51,6 +51,7 @@ export class Crypto extends core.Crypto implements core.CryptoStorages, types.IS
   private initialized: boolean;
 
   public templateBuilder: types.ITemplateBuilder = new TemplateBuilder();
+  public onAlwaysAuthenticate?: types.AlwaysAuthenticateHandle;
 
   /**
    * Creates an instance of WebCrypto.

--- a/src/key.ts
+++ b/src/key.ts
@@ -49,6 +49,10 @@ export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extend
   public id: string;
   public p11Object: graphene.Key | graphene.SecretKey | graphene.PublicKey | graphene.PrivateKey;
 
+  /**
+   * If `true`, the user has to supply the PIN for each use (sign or decrypt) with the key. Use `crypto.onAlwaysAuthenticate` handler to customize this behavior.
+   * @since v2.6.0
+   */
   public alwaysAuthenticate?: boolean | undefined;
 
   public override type: KeyType = "secret";

--- a/src/key.ts
+++ b/src/key.ts
@@ -2,7 +2,7 @@
 import * as core from "webcrypto-core";
 
 import * as graphene from "graphene-pk11";
-import { Pkcs11KeyAlgorithm } from "./types";
+import { AlwaysAuthenticateParams, Pkcs11KeyAlgorithm } from "./types";
 
 export interface ITemplatePair {
   privateKey: graphene.ITemplate;
@@ -16,7 +16,7 @@ export interface CryptoKeyJson<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm
   extractable: boolean;
 }
 
-export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extends core.CryptoKey {
+export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extends core.CryptoKey implements AlwaysAuthenticateParams {
 
   public static defaultKeyAlgorithm(): Pkcs11KeyAlgorithm {
     const alg: Pkcs11KeyAlgorithm = {
@@ -48,6 +48,8 @@ export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extend
 
   public id: string;
   public p11Object: graphene.Key | graphene.SecretKey | graphene.PublicKey | graphene.PrivateKey;
+
+  public alwaysAuthenticate?: boolean | undefined;
 
   public override type: KeyType = "secret";
   public override extractable: boolean = false;
@@ -109,6 +111,7 @@ export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extend
   protected initPrivateKey(key: graphene.PrivateKey): void {
     this.p11Object = key;
     this.type = "private";
+    this.alwaysAuthenticate = key.alwaysAuthenticate;
     try {
       // Yubico throws CKR_ATTRIBUTE_TYPE_INVALID
       this.extractable = key.extractable;

--- a/src/mechs/ec/crypto.ts
+++ b/src/mechs/ec/crypto.ts
@@ -32,6 +32,9 @@ export class EcCrypto implements types.IContainer {
         sensitive: algorithm.sensitive,
         extractable,
         usages: keyUsages,
+      };
+      if (algorithm.alwaysAuthenticate) {
+        attrs.alwaysAuthenticate = true;
       }
       const privateTemplate = this.createTemplate({
         action: "generate",
@@ -158,6 +161,7 @@ export class EcCrypto implements types.IContainer {
   }
 
   protected importJwkPrivateKey(jwk: JsonWebKey, algorithm: types.Pkcs11EcKeyImportParams, extractable: boolean, keyUsages: KeyUsage[]): EcCryptoKey {
+
     const template = this.createTemplate({
       action: "import",
       type: "private",
@@ -166,6 +170,7 @@ export class EcCrypto implements types.IContainer {
         token: algorithm.token,
         sensitive: algorithm.sensitive,
         label: algorithm.label,
+        alwaysAuthenticate: algorithm.alwaysAuthenticate,
         extractable,
         usages: keyUsages,
       },
@@ -200,8 +205,8 @@ export class EcCrypto implements types.IContainer {
     if (namedCurve.name === "curve25519") {
       pointEc = utils.b64UrlDecode(jwk.x!);
     } else {
-      const point = core.EcUtils.encodePoint({ x: utils.b64UrlDecode(jwk.x!), y: utils.b64UrlDecode(jwk.y!) }, namedCurve.size)
-      const derPoint = asn1Schema.AsnConvert.serialize(new asn1Schema.OctetString(point))
+      const point = core.EcUtils.encodePoint({ x: utils.b64UrlDecode(jwk.x!), y: utils.b64UrlDecode(jwk.y!) }, namedCurve.size);
+      const derPoint = asn1Schema.AsnConvert.serialize(new asn1Schema.OctetString(point));
       pointEc = Buffer.from(derPoint);
     }
     template.pointEC = pointEc;

--- a/src/mechs/rsa/crypto.ts
+++ b/src/mechs/rsa/crypto.ts
@@ -10,7 +10,7 @@ import * as utils from "../../utils";
 
 import { RsaCryptoKey } from "./key";
 
-const HASH_PREFIXES: { [alg: string]: Buffer } = {
+const HASH_PREFIXES: { [alg: string]: Buffer; } = {
   "sha-1": Buffer.from([0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14]),
   "sha-256": Buffer.from([0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20]),
   "sha-384": Buffer.from([0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30]),
@@ -36,7 +36,11 @@ export class RsaCrypto implements types.IContainer {
       sensitive: algorithm.sensitive,
       extractable,
       usages: keyUsages,
+    };
+    if (algorithm.alwaysAuthenticate) {
+      attrs.alwaysAuthenticate = true;
     }
+
     const privateTemplate = this.createTemplate({
       action: "generate",
       type: "private",
@@ -95,7 +99,7 @@ export class RsaCrypto implements types.IContainer {
         const jwk = await this.exportJwkPublicKey(key);
         const spki = this.jwk2spki(jwk);
         const asn = asnSchema.AsnConvert.parse(spki, core.asn1.PublicKeyInfo);
-        return asn.publicKey
+        return asn.publicKey;
       }
       default:
         throw new core.OperationError("format: Must be 'raw', 'jwk', 'pkcs8' or 'spki'");
@@ -241,6 +245,7 @@ export class RsaCrypto implements types.IContainer {
         sensitive: algorithm.sensitive,
         label: algorithm.label,
         extractable,
+        alwaysAuthenticate: algorithm.alwaysAuthenticate,
         usages: keyUsages
       },
     });

--- a/src/template_builder.ts
+++ b/src/template_builder.ts
@@ -22,7 +22,7 @@ export class TemplateBuilder implements types.ITemplateBuilder {
       }
     } else {
       if (attributes.label) {
-        template.label = attributes.label
+        template.label = attributes.label;
       }
       if (attributes.id) {
         template.id = Buffer.from(pvtsutils.BufferSourceConverter.toArrayBuffer(attributes.id));
@@ -48,6 +48,9 @@ export class TemplateBuilder implements types.ITemplateBuilder {
             decrypt,
             unwrap,
           });
+          if (attributes.alwaysAuthenticate) {
+            template.alwaysAuth = true;
+          }
           break;
         case "public":
           Object.assign<types.ITemplate, types.ITemplate>(template, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,12 @@ import * as pvtsutils from "pvtsutils";
 export type ITemplate = graphene.ITemplate;
 
 export interface Pkcs11Attributes {
-  id?: pvtsutils.BufferSource
+  id?: pvtsutils.BufferSource;
   token?: boolean;
   sensitive?: boolean;
   label?: string;
   extractable?: boolean;
+  alwaysAuthenticate?: boolean;
   usages?: KeyUsage[];
 }
 
@@ -30,12 +31,16 @@ export interface ITemplateBuilder {
    * Returns a PKCS#11 template
    * @param params Template build parameters
    */
-  build(params: ITemplateBuildParameters): ITemplate
+  build(params: ITemplateBuildParameters): ITemplate;
 }
+
+export type AlwaysAuthenticateHandleResult = string | null;
+export type AlwaysAuthenticateHandle = (key: CryptoKey, crypto: ISessionContainer) => AlwaysAuthenticateHandleResult | Promise<AlwaysAuthenticateHandleResult>;
 
 export interface ISessionContainer {
   readonly session: graphene.Session;
-  templateBuilder: ITemplateBuilder
+  templateBuilder: ITemplateBuilder;
+  onAlwaysAuthenticate?: AlwaysAuthenticateHandle;
 }
 
 export interface IContainer {
@@ -86,21 +91,26 @@ export interface Pkcs11Params {
   sensitive?: boolean;
   label?: string;
 }
+
+export interface AlwaysAuthenticateParams {
+  alwaysAuthenticate?: boolean;
+}
+
 export interface Pkcs11KeyGenParams extends Algorithm, Pkcs11Params { }
 
 export interface Pkcs11AesKeyGenParams extends AesKeyGenParams, Pkcs11KeyGenParams { }
 
 export interface Pkcs11HmacKeyGenParams extends HmacKeyGenParams, Pkcs11KeyGenParams { }
 
-export interface Pkcs11EcKeyGenParams extends EcKeyGenParams, Pkcs11KeyGenParams { }
+export interface Pkcs11EcKeyGenParams extends EcKeyGenParams, Pkcs11KeyGenParams, AlwaysAuthenticateParams { }
 
-export interface Pkcs11RsaHashedKeyGenParams extends RsaHashedKeyGenParams, Pkcs11KeyGenParams { }
+export interface Pkcs11RsaHashedKeyGenParams extends RsaHashedKeyGenParams, Pkcs11KeyGenParams, AlwaysAuthenticateParams { }
 
 export interface Pkcs11KeyImportParams extends Algorithm, Pkcs11Params { }
 
-export interface Pkcs11EcKeyImportParams extends EcKeyImportParams, Pkcs11KeyImportParams { }
+export interface Pkcs11EcKeyImportParams extends EcKeyImportParams, Pkcs11KeyImportParams, AlwaysAuthenticateParams { }
 
-export interface Pkcs11RsaHashedImportParams extends RsaHashedImportParams, Pkcs11KeyImportParams { }
+export interface Pkcs11RsaHashedImportParams extends RsaHashedImportParams, Pkcs11KeyImportParams, AlwaysAuthenticateParams { }
 
 export interface Pkcs11HmacKeyImportParams extends HmacImportParams, Pkcs11KeyImportParams { }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,10 @@ export interface Pkcs11Attributes {
   sensitive?: boolean;
   label?: string;
   extractable?: boolean;
+  /**
+   * If `true`, the user has to supply the PIN for each use (sign or decrypt) with the key. Use `crypto.onAlwaysAuthenticate` handler to customize this behavior.
+   * @since v2.6.0
+   */
   alwaysAuthenticate?: boolean;
   usages?: KeyUsage[];
 }
@@ -40,6 +44,10 @@ export type AlwaysAuthenticateHandle = (key: CryptoKey, crypto: ISessionContaine
 export interface ISessionContainer {
   readonly session: graphene.Session;
   templateBuilder: ITemplateBuilder;
+  /**
+   * Returns the PIN for the force re-authentication. Re-authentication occurs by calling sign or decrypt functions.
+   * @since v2.6.0
+   */
   onAlwaysAuthenticate?: AlwaysAuthenticateHandle;
 }
 
@@ -93,6 +101,11 @@ export interface Pkcs11Params {
 }
 
 export interface AlwaysAuthenticateParams {
+
+  /**
+   * If `true`, the user has to supply the PIN for each use (sign or decrypt) with the key. Use `crypto.onAlwaysAuthenticate` handler to customize this behavior.
+   * @since v2.6.0
+   */
   alwaysAuthenticate?: boolean;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,7 +169,7 @@ export function getProviderInfo(slot: graphene.Slot): ProviderInfo {
 export async function alwaysAuthenticate(key: CryptoKey, container: ISessionContainer): Promise<void> {
   if (key.key instanceof graphene.PrivateKey && key.key.alwaysAuthenticate) {
     if (!container.onAlwaysAuthenticate) {
-      throw new core.CryptoError("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method");
+      throw new core.CryptoError("Crypto key requires re-authentication, but Crypto doesn't have 'onAlwaysAuthenticate' method");
     }
 
     const pin = await container.onAlwaysAuthenticate(key, container);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,10 @@
 import * as crypto from "crypto";
 import * as graphene from "graphene-pk11";
 import * as pvtsutils from "pvtsutils";
+import * as core from "webcrypto-core";
 import { ID_DIGEST } from "./const";
-import { ProviderInfo } from "./types";
+import { ISessionContainer, ProviderInfo } from "./types";
+import { CryptoKey } from "./key";
 
 export interface HashedAlgorithm extends Algorithm {
   hash: AlgorithmIdentifier;
@@ -162,4 +164,17 @@ export function getProviderInfo(slot: graphene.Slot): ProviderInfo {
   }
 
   return provider;
+}
+
+export async function alwaysAuthenticate(key: CryptoKey, container: ISessionContainer): Promise<void> {
+  if (key.key instanceof graphene.PrivateKey && key.key.alwaysAuthenticate) {
+    if (!container.onAlwaysAuthenticate) {
+      throw new core.CryptoError("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method");
+    }
+
+    const pin = await container.onAlwaysAuthenticate(key, container);
+    if (pin) {
+      container.session.login(pin, graphene.UserType.CONTEXT_SPECIFIC);
+    }
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,6 +166,12 @@ export function getProviderInfo(slot: graphene.Slot): ProviderInfo {
   return provider;
 }
 
+/**
+ * Checks and calls `onAlwaysAuthenticate` method
+ * @param key Crypto key
+ * @param container Crypto container
+ * @throws Throws CryptoError if `alwaysAuthenticate` is enabled for the key and `onAlwaysAuthenticate` method of the container is undefined
+ */
 export async function alwaysAuthenticate(key: CryptoKey, container: ISessionContainer): Promise<void> {
   if (key.key instanceof graphene.PrivateKey && key.key.alwaysAuthenticate) {
     if (!container.onAlwaysAuthenticate) {

--- a/test/always_auth.ts
+++ b/test/always_auth.ts
@@ -4,6 +4,8 @@ import { CryptoKey, Pkcs11RsaHashedImportParams, Pkcs11RsaHashedKeyGenParams } f
 import { config, crypto } from "./config";
 import { is } from "./helper";
 
+const ERROR_METHOD_REQUIRED = "Crypto key requires re-authentication, but Crypto doesn't have 'onAlwaysAuthenticate' method";
+
 (is(config.pin === undefined, "Tests require PIN usage")
   ? context.skip
   : context)
@@ -108,7 +110,7 @@ import { is } from "./helper";
               await assert.rejects(async () => {
                 await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
               },
-                new Error("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method"));
+                new Error(ERROR_METHOD_REQUIRED));
             });
 
             it("skip C_Login", async () => {
@@ -150,7 +152,7 @@ import { is } from "./helper";
               await assert.rejects(async () => {
                 await crypto.subtle.decrypt(v.algorithm, keys.privateKey, data);
               },
-                new Error("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method"));
+                new Error(ERROR_METHOD_REQUIRED));
             });
 
             it("skip C_Login", async () => {

--- a/test/always_auth.ts
+++ b/test/always_auth.ts
@@ -1,0 +1,192 @@
+import * as assert from "assert";
+import { Convert } from "pvtsutils";
+import { CryptoKey, Pkcs11RsaHashedImportParams, Pkcs11RsaHashedKeyGenParams } from "../src";
+import { config, crypto } from "./config";
+import { is } from "./helper";
+
+(is(config.pin === undefined, "Tests require PIN usage")
+  ? context.skip
+  : context)
+  ("CKA_ALWAYS_AUTHENTICATE", () => {
+
+    type RsaSsaAlgorithm = RsaHashedKeyGenParams;
+    type RsaPssAlgorithm = RsaHashedKeyGenParams & RsaPssParams;
+    type RsaOaepAlgorithm = RsaHashedKeyGenParams & RsaOaepParams;
+    type EcdsaAlgorithm = EcKeyGenParams & EcdsaParams;
+    type VectorAlgorithms =
+      RsaSsaAlgorithm |
+      RsaPssAlgorithm |
+      RsaOaepAlgorithm |
+      EcdsaAlgorithm;
+
+    interface Vector {
+      algorithm: VectorAlgorithms,
+      keyUsage: "sign" | "encrypt",
+    }
+
+    const vectors: Vector[] = [
+      {
+        algorithm: {
+          name: "RSASSA-PKCS1-v1_5",
+          hash: "SHA-256",
+          publicExponent: new Uint8Array([1, 0, 1]),
+          modulusLength: 2048,
+        },
+        keyUsage: "sign",
+      },
+      {
+        algorithm: {
+          name: "RSA-PSS",
+          hash: "SHA-256",
+          publicExponent: new Uint8Array([1, 0, 1]),
+          modulusLength: 2048,
+          saltLength: 10,
+        },
+        keyUsage: "sign",
+      },
+      {
+        algorithm: {
+          name: "RSA-OAEP",
+          hash: "SHA-1",
+          publicExponent: new Uint8Array([1, 0, 1]),
+          modulusLength: 2048,
+        },
+        keyUsage: "encrypt",
+      },
+      {
+        algorithm: {
+          name: "ECDSA",
+          hash: "SHA-256",
+          namedCurve: "P-256",
+        },
+        keyUsage: "sign",
+      },
+    ];
+
+    vectors.forEach(v => {
+      context(v.algorithm.name, () => {
+
+        let keys: CryptoKeyPair;
+        let pin: string;
+        const usages: KeyUsage[] = [];
+        switch (v.keyUsage) {
+          case "sign":
+            usages.push("sign", "verify");
+            break;
+          case "encrypt":
+            usages.push("encrypt", "decrypt");
+            break;
+        }
+
+        before(async () => {
+          assert.ok(config.pin, "PIN is required");
+          pin = config.pin;
+
+          keys = await crypto.subtle.generateKey({
+            ...v.algorithm,
+            alwaysAuthenticate: true,
+          } as Pkcs11RsaHashedKeyGenParams, true, usages);
+
+          assert.strictEqual((keys.privateKey as CryptoKey).alwaysAuthenticate, true);
+          assert.strictEqual((keys.publicKey as CryptoKey).alwaysAuthenticate, undefined);
+        });
+
+        it("importKey", async () => {
+          const pkcs8 = await crypto.subtle.exportKey("pkcs8", keys.privateKey);
+          const key = await crypto.subtle.importKey("pkcs8", pkcs8, {
+            ...v.algorithm,
+            alwaysAuthenticate: true,
+          } as Pkcs11RsaHashedImportParams, false, usages);
+          assert.strictEqual(key.alwaysAuthenticate, true);
+        });
+
+        switch (v.keyUsage) {
+          case "sign":
+            it("onAlwaysAuthenticate is undefined", async () => {
+              crypto.onAlwaysAuthenticate = undefined;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
+              },
+                new Error("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method"));
+            });
+
+            it("skip C_Login", async () => {
+              crypto.onAlwaysAuthenticate = () => null;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
+              },
+                (e) => e instanceof Error && e.message.includes("CKR_USER_NOT_LOGGED_IN"));
+            });
+
+            it(v.keyUsage, async () => {
+              crypto.onAlwaysAuthenticate = () => pin;
+
+              const signature1 = await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
+              assert.ok(signature1);
+              const signature2 = await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
+              assert.ok(signature2);
+            });
+
+            it(`${v.keyUsage} with incorrect PIN`, async () => {
+              const pin = config.pin;
+              assert.ok(pin, "PIN is required");
+              crypto.onAlwaysAuthenticate = () => `${pin}!`;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.sign(v.algorithm, keys.privateKey, new Uint8Array(10));
+              },
+                (e) => {
+                  return e instanceof Error && e.message.includes("CKR_PIN_INCORRECT");
+                });
+            });
+            break;
+          case "encrypt":
+            const data = new Uint8Array(10);
+            it("onAlwaysAuthenticate is undefined", async () => {
+              crypto.onAlwaysAuthenticate = undefined;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.decrypt(v.algorithm, keys.privateKey, data);
+              },
+                new Error("Crypto key requires re-authentication but Crypto doesn't have `onAlwaysAuthenticate` method"));
+            });
+
+            it("skip C_Login", async () => {
+              crypto.onAlwaysAuthenticate = () => null;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.decrypt(v.algorithm, keys.privateKey, data);
+              },
+                (e) => e instanceof Error && e.message.includes("CKR_USER_NOT_LOGGED_IN"));
+            });
+
+            it(v.keyUsage, async () => {
+              crypto.onAlwaysAuthenticate = () => pin;
+
+              let i = 2;
+              while (i--) {
+                const enc = await crypto.subtle.encrypt(v.algorithm, keys.publicKey, data);
+                const dec = await crypto.subtle.decrypt(v.algorithm, keys.privateKey, enc);
+                assert.strictEqual(Convert.ToHex(dec), Convert.ToHex(data));
+              }
+            });
+
+            it(`${v.keyUsage} with incorrect PIN`, async () => {
+              const pin = config.pin;
+              assert.ok(pin, "PIN is required");
+              crypto.onAlwaysAuthenticate = () => `${pin}!`;
+
+              await assert.rejects(async () => {
+                await crypto.subtle.decrypt(v.algorithm, keys.privateKey, data);
+              },
+                (e) => {
+                  return e instanceof Error && e.message.includes("CKR_PIN_INCORRECT");
+                });
+            });
+            break;
+        }
+      });
+    });
+  });

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -21,6 +21,13 @@ function testManufacturer(manufacturerID: string, message: string): boolean {
   return false;
 }
 
+export function is(condition: boolean, message: string): boolean {
+  if (condition) {
+    console.warn("    \x1b[33mWARN:\x1b[0m Test is not supported. %s", message || "");
+  }
+  return condition;
+}
+
 export function isSoftHSM(message: string): boolean {
   return testManufacturer("SoftHSMv2", message);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,109 +247,109 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@peculiar/asn1-cms@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.1.8.tgz#0f2591e46f9ee360c1f834ff191b44be49dbfc6c"
-  integrity sha512-xWW1thg1V+SowpYkzuJsQdKg0n/myfwxajgjXKXyxYbIUqer4+2wRAA8lz/0//Lt1cyuG/3slaewncus9QM3Yw==
+"@peculiar/asn1-cms@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.2.0.tgz#fd5bab6135360008e9e7204616aa3d7e36b2b875"
+  integrity sha512-8lJe4OC83NUA/rP4/J8Zjd3Lsxbx8lkBcVWDkUJNFAsfWqDdhlwmNyhg8h0x0jr8NJ6QOCTwJ18VIs58X54/ow==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    "@peculiar/asn1-x509-attr" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    "@peculiar/asn1-x509-attr" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-csr@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.1.8.tgz#72948e87f69c8645bf379b591260a084e61f5d7c"
-  integrity sha512-orsY1nJ/2fopMabioLdXBZeuxlXAEkXfqBl6hEYHUG9Ia5uoAxnT5yxmn78RvbcdDqp9GBSmh653zGyYX8nuSg==
+"@peculiar/asn1-csr@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.2.0.tgz#f4881c69c9eb8db902c3ddc71d461cfe894b700b"
+  integrity sha512-kj/pjv+Mn0culffDaxjaInZPvoAcJUuJvk3JUeGNoe5N9pIK6Bcrtt7dfA1u+NgI7K1y1TBDAzTQoYxfxmsRbA==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-ecc@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.1.8.tgz#3ad6d5ab44cbf2ee0ec6bcaa2575c8e9c1148947"
-  integrity sha512-MoIWxTP/USioOSwjDvUJL2esWzZkrYdlsLQfcWUOn5jVLe+q1nSHBubBjhXtjR9iIN0LnXQ629nTNdhLznx+jQ==
+"@peculiar/asn1-ecc@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.2.0.tgz#16c8cc69d3a44f6f9425473f63407099eb3468cd"
+  integrity sha512-/fMm9loLLLQcbZSGM0B4eNedgmagJPvwqklVRtG8OBTLidKZN3U/dmiemiKx8hf3w5IYwu52OxMSch88BHpuGQ==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-pfx@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.1.8.tgz#1d6798c78493d23ce68d7cec0169049447e73606"
-  integrity sha512-iX5vI9unoR0dT3ME1SgKSHGzsGowTVOolzSz68+jRV3B6nSJljHdiriVyUXIz+pGFSShRPPgy+xagGmo9A9cYg==
+"@peculiar/asn1-pfx@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.2.0.tgz#e4e10df033ff40d106082fbd87c07e9d889891e3"
+  integrity sha512-FrGzBQpVr2IwY6iYcmN5cp8IRGDhDsM+EzBRUs6fodvAGm8cchGid9WZszqRpBG8YCOBZXZ38bR0r6gdmH9q7g==
   dependencies:
-    "@peculiar/asn1-cms" "^2.1.8"
-    "@peculiar/asn1-pkcs8" "^2.1.8"
-    "@peculiar/asn1-rsa" "^2.1.8"
-    "@peculiar/asn1-schema" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-cms" "^2.2.0"
+    "@peculiar/asn1-pkcs8" "^2.2.0"
+    "@peculiar/asn1-rsa" "^2.2.0"
+    "@peculiar/asn1-schema" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-pkcs8@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.1.8.tgz#997cbf35f37ee661e723e96750b944f6703d57c7"
-  integrity sha512-2WbAoDQP8Gs0mtyzXlYbSvJ4QPiYuBNasIfpkRV4fjNNtCh80O3gdONa4B5xWWGhLbitjDE68ZigwrXlVACr1g==
+"@peculiar/asn1-pkcs8@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.2.0.tgz#6b0f156d26b4acd4eb03bea848e579a12786fddd"
+  integrity sha512-tbVTUYevN1PftXz8qKvvddroGC1nHZtvsVCTRMGwMV9x5MNs6YWqxAkM5jAV75PVfwQvWSbrvQmQlo2epBYjtg==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-pkcs9@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.1.8.tgz#c581ece374056e029d4c719ea733a6e54b49341f"
-  integrity sha512-VoSWvUalTtnXpnDXItGpcWVNn5RI2iZ+poDMUEYg3qmHd9V6c/ieI3jmMbSPKlPq4uiG6BxfZwCCbDAyDa70vg==
+"@peculiar/asn1-pkcs9@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.2.0.tgz#2954cb01c722c126aaf493f354b8d9d3b0ecfde9"
+  integrity sha512-gJPS7/64OjQSFPFBys2klRb32bKBCraPOmrfzuTM3FvUh+yroomG8RBtnDR4Xn8QxzOIwvMape+FqPsNQ2ldPg==
   dependencies:
-    "@peculiar/asn1-cms" "^2.1.8"
-    "@peculiar/asn1-pfx" "^2.1.8"
-    "@peculiar/asn1-pkcs8" "^2.1.8"
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    "@peculiar/asn1-x509-attr" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-cms" "^2.2.0"
+    "@peculiar/asn1-pfx" "^2.2.0"
+    "@peculiar/asn1-pkcs8" "^2.2.0"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    "@peculiar/asn1-x509-attr" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-rsa@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.1.8.tgz#26d46e83df53095387fa9d3ae5fde061f9f64590"
-  integrity sha512-p3RuAmbetJUy7hAOwkBsGp4vULjrpSQFZvz9OT83bkaOVHOGTzpc42Q02869hIX5eAB3LdZqct+atcpaHR6c/w==
+"@peculiar/asn1-rsa@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.2.0.tgz#e8ad370a68ca9066cd9ff8441d16c56970b312f5"
+  integrity sha512-t6CIvXYpjEzos5iXwg6QSFdKce3c3Iw9M658qARdIpbWDvosNHeVn7e97IYdmJU0sDS4ech1aS2GLuKFFKmcew==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.1.8", "@peculiar/asn1-schema@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.1.9.tgz#273f4b1a9487dfea37c7999aca2cd12c79674673"
-  integrity sha512-Ipio+pXGpL/Vb0qB4GnOgFMgc1RAhKHOVy24rQYLvmOAVp9z/aFb+VdIiQH09NjgvGVmaWOUqSWd9vRHk3xbrg==
+"@peculiar/asn1-schema@^2.1.6", "@peculiar/asn1-schema@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.2.0.tgz#d8a54527685c8dee518e6448137349444310ad64"
+  integrity sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==
   dependencies:
-    asn1js "^3.0.4"
+    asn1js "^3.0.5"
     pvtsutils "^1.3.2"
     tslib "^2.4.0"
 
-"@peculiar/asn1-x509-attr@^2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.1.8.tgz#c55d4ccfc3c1ce11e0f158f1e2ad9326961fe650"
-  integrity sha512-JtSjcCLOXILesj6lC3kqe2qVvRcTcWLozjO94cDVKWtLX04/QiwZbhetG9OPLaE0DFfErUz1/DC06swAO4yGRQ==
+"@peculiar/asn1-x509-attr@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.2.0.tgz#16505dddf35aa0d4c1708ccc9b60e57be0cf54a0"
+  integrity sha512-SWX6pYWTxNy2bBcvOJriBhC7CaqvD9JQ+XUWrmiVrbw8hmzJS3Jcv6JMRfSuitjmmEE+W2wvY0s8zmghDrQK+A==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.8"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
+    asn1js "^3.0.5"
     tslib "^2.4.0"
 
-"@peculiar/asn1-x509@^2.1.3", "@peculiar/asn1-x509@^2.1.8", "@peculiar/asn1-x509@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.1.9.tgz#ce5db9443531f67a06a663d928578f2b3dc1088d"
-  integrity sha512-mqU8ZlWaBfDSG/iafCYKOa9N7scXiaXfHNgOyqG0GIPZGGjNeeBjgLRrlup6L8/Ipvlun5VIm7vNJdR8/XIqtg==
+"@peculiar/asn1-x509@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.2.0.tgz#aba335e1264f8e2eea8f39f5157c421e3fb32c8a"
+  integrity sha512-YORcf7XFy9TKWGnPmK2MNQqAJgIvGNaCrK8vUF/ZRO+BnahZJOgX2HuEiEmoAozZpSlyJnI6CGJOABOjPiDucA==
   dependencies:
-    "@peculiar/asn1-schema" "^2.1.9"
-    asn1js "^3.0.4"
+    "@peculiar/asn1-schema" "^2.2.0"
+    asn1js "^3.0.5"
     ipaddr.js "^2.0.1"
     pvtsutils "^1.3.2"
     tslib "^2.4.0"
@@ -369,18 +369,18 @@
     pvtsutils "^1.0.14"
     tslib "^2.0.1"
 
-"@peculiar/x509@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.7.0.tgz#71c32758bacc3a7558a355d145810b8da3d819e9"
-  integrity sha512-nR47H4AzFeCaRDgMX07wdv2ovomi6G/GmrJD+TNsMccTvT5Zu384s9l6Re2Qp1MJUst9fXuIifzIhKvMf8r6GA==
+"@peculiar/x509@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.8.1.tgz#02c5e29d0a85ed22341c624c9e812c34c92d3499"
+  integrity sha512-6f3RPkMvZmnaLIYTu4NZO6xoEt0PmR97UCuRhMLR2ou95ogC20nr4GQIyRnSfDgvexbb9HX1eNiaKb+N49Klfw==
   dependencies:
-    "@peculiar/asn1-cms" "^2.1.8"
-    "@peculiar/asn1-csr" "^2.1.8"
-    "@peculiar/asn1-ecc" "^2.1.8"
-    "@peculiar/asn1-pkcs9" "^2.1.8"
-    "@peculiar/asn1-rsa" "^2.1.8"
-    "@peculiar/asn1-schema" "^2.1.8"
-    "@peculiar/asn1-x509" "^2.1.3"
+    "@peculiar/asn1-cms" "^2.2.0"
+    "@peculiar/asn1-csr" "^2.2.0"
+    "@peculiar/asn1-ecc" "^2.2.0"
+    "@peculiar/asn1-pkcs9" "^2.2.0"
+    "@peculiar/asn1-rsa" "^2.2.0"
+    "@peculiar/asn1-schema" "^2.2.0"
+    "@peculiar/asn1-x509" "^2.2.0"
     pvtsutils "^1.3.2"
     reflect-metadata "^0.1.13"
     tslib "^2.4.0"
@@ -419,10 +419,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
-"@types/node@^17.0.44":
-  version "17.0.44"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.44.tgz#16dd0bb5338f016d8ca10631789f0d0612fe5d5b"
-  integrity sha512-gWYiOlu6Y4oyLYBvsJAPlwHbC8H4tX+tLsHy6Ee976wedwwZKrG2hFl3Y/HiH6bIyLTbDWQexQF/ohwKkOpUCg==
+"@types/node@^18.6.1":
+  version "18.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
+  integrity sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -508,7 +508,7 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-asn1js@^3.0.1, asn1js@^3.0.4:
+asn1js@^3.0.1, asn1js@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
   integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
@@ -902,13 +902,13 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphene-pk11@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/graphene-pk11/-/graphene-pk11-2.3.0.tgz#4fd3d0ab6c633decd9d443a999c4a257a1650c8e"
-  integrity sha512-mgc3ux5yyJs0G5YAaO3hkNT4D86D1bPgLQH4ts2Wfn41braLAC2utlzB7R9bp4w9zPNPfJPXPb8mE8md/1BEZg==
+graphene-pk11@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/graphene-pk11/-/graphene-pk11-2.3.2.tgz#988cba2f977fa9e4b71f055e6a46c295ede1c981"
+  integrity sha512-fhRM7BF3MYAL6A6xgCLki/CHKfZpO8gRFpddQc/hqdPow6dymVBmgdKK23OE0HbG3LhB2yz8O+GkL2EejqXW7g==
   dependencies:
-    pkcs11js "^1.2.3"
-    tslib "^2.3.1"
+    pkcs11js "^1.3.0"
+    tslib "^2.4.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1396,7 +1396,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pkcs11js@^1.2.3, pkcs11js@^1.3.0:
+pkcs11js@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/pkcs11js/-/pkcs11js-1.3.0.tgz#7df841051a17c053723fa66758ab6a82bca32ef7"
   integrity sha512-owI+M6Gpw0cEU47cTt2eWQs4Iqm9zRyobiJ0q37wIgOrK8BcXVuRM3eVGH58QxYWhItMcRiEBUTE8HUHZX+beQ==
@@ -1506,10 +1506,10 @@ rollup-plugin-typescript2@^0.32.1:
     resolve "^1.20.0"
     tslib "^2.4.0"
 
-rollup@^2.75.6:
-  version "2.75.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.6.tgz#ac4dc8600f95942a0180f61c7c9d6200e374b439"
-  integrity sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==
+rollup@^2.77.0:
+  version "2.77.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.0.tgz#749eaa5ac09b6baa52acc076bc46613eddfd53f4"
+  integrity sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -1662,10 +1662,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ts-node@^10.8.1:
-  version "10.8.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.1.tgz#ea2bd3459011b52699d7e88daa55a45a1af4f066"
-  integrity sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
@@ -1686,7 +1686,7 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -1736,10 +1736,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.7.3:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
-  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## API changes

Works for `ECDSA`, `RSASSA-PKCS1-v1_5`, `RSA-PSS`, and `RSA-OAEP` algorithms

### Crypto

```js
// Adds AlwaysAuthenticateHandler to `crypto` object
// App uses returned string value for `C_Login(pin, CKU_CONTEXT_SPECIFIC)` calling imideatly after C_SignInit/C_DecryptInit functions 
crypto.onAlwaysAuthenticate = (key, container) => {
  return pin;
}
```

If `AlwaysAuthenticateHandler` returns `null` app skips `C_Login` function and PKCS#11 provider returns `CKR_USER_NOT_LOGGED_IN` status code

If `onAlwaysAuthenticate` is undefined and the private key has enabled `CKA_ALWAYS_AUTHENTICATE` the app throws the error on sign/decrypt operations - `Crypto key requires re-authentication, but Crypto doesn't have 'onAlwaysAuthenticate' method`

### Generate key

```js
const keys = await crypto.subtle.generateKey({
  name: "ECDSA",
  namedCurve: "P-256",
  alwaysAuthenticate: true, // enables CKA_ALWAYS_AUTHENTICATE for CKO_PRIVATE
 }, false, ["sign", "verify"]);
```
### Import key

```js
const key = await crypto.subtle.importKey(
  "pkcs8",
  pkcs8Raw,
  {
    name: "ECDSA",
    namedCurve: "P-256",
    alwaysAuthenticate: true, // enables CKA_ALWAYS_AUTHENTICATE for CKO_PRIVATE
   }, 
   false, 
   ["sign", "verify"]);
```

### Crypto key

Private crypto key includes the `alwaysAuthenticate` boolean field, which represents the  `CKA_ALWAYS_AUTHENTICATE` attribute of PKCS#11 private key

```js
RsaCryptoKey [CryptoKey] {
  type: 'private',
  extractable: false,
  usages: [ 'sign' ],
  alwaysAuthenticate: true,
  algorithm: {
    name: 'RSASSA-PKCS1-v1_5',
    hash: { name: 'SHA-256' },
    publicExponent: Uint8Array(3) [ 1, 0, 1 ],
    modulusLength: 2048,
    label: 'RSA',
    sensitive: false,
    token: false
  },
```