### PR TITLE
Added NO-HASH option for ECDSA, for cases the data is already hashed

### DIFF
--- a/src/mechs/ec/crypto.ts
+++ b/src/mechs/ec/crypto.ts
@@ -156,6 +156,9 @@ export class EcCrypto implements types.IContainer {
   }
 
   public prepareData(hashAlgorithm: string, data: Buffer): Buffer {
+    if (hashAlgorithm === "NO-HASH") {
+      return utils.prepareData(data)
+    } else {
     // use nodejs crypto for digest calculating
     return utils.digest(hashAlgorithm.replace("-", ""), data);
   }

--- a/src/mechs/ec/ec_dsa.ts
+++ b/src/mechs/ec/ec_dsa.ts
@@ -116,6 +116,9 @@ export class EcdsaProvider extends core.EcdsaProvider implements types.IContaine
       case "SHA-512":
         algName = "ECDSA_SHA512";
         break;
+      case "NO-HASH":
+        algName = "ECDSA";
+        break;
       default:
         throw new core.OperationError(`Cannot create PKCS11 mechanism from algorithm '${hashAlg}'`);
     }


### PR DESCRIPTION
We ran into a use case where the data to be signed via ECDSA is already hashed, and should not be hashed again. I added the option to do with the hash algorithm "NO-HASH".
This is in conjuncture with a [webcrypto-core pull request](https://github.com/PeculiarVentures/webcrypto-core/pull/64)