### PR TITLE
Fix: TypeScript Type Error when exactOptionalPropertyTypes is enabled

### DIFF
--- a/src/key.ts
+++ b/src/key.ts
@@ -53,7 +53,7 @@ export class CryptoKey<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extend
    * If `true`, the user has to supply the PIN for each use (sign or decrypt) with the key. Use `crypto.onAlwaysAuthenticate` handler to customize this behavior.
    * @since v2.6.0
    */
-  public alwaysAuthenticate?: boolean | undefined;
+  public alwaysAuthenticate?: boolean;
 
   public override type: KeyType = "secret";
   public override extractable: boolean = false;


### PR DESCRIPTION
This PR should resolve issue #92.

Right now, when `exactOptionalPropertyTypes: true`, running `npx tsc` results in the following error:

```
node_modules/node-webcrypto-p11/build/index.d.ts:156:15 - error TS2420: Class 'CryptoKey$1<T>' incorrectly implements interface 'AlwaysAuthenticateParams'.
  Types of property 'alwaysAuthenticate' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'boolean'.
      Type 'undefined' is not assignable to type 'boolean'.

156 declare class CryptoKey$1<T extends Pkcs11KeyAlgorithm = Pkcs11KeyAlgorithm> extends core.CryptoKey implements AlwaysAuthenticateParams {
                  ~~~~~~~~~~~


Found 1 error in node_modules/node-webcrypto-p11/build/index.d.ts:156
```

This PR should fix that.